### PR TITLE
Refactor mobile barang view to use app layout and Vite

### DIFF
--- a/resources/views/mobile/barang.blade.php
+++ b/resources/views/mobile/barang.blade.php
@@ -1,13 +1,5 @@
 <x-app-layout>
-    <!DOCTYPE html>
-    <html lang="id">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Form Input Barang - Mobile</title>
-        <script src="https://cdn.tailwindcss.com"></script>
-    </head>
-    <body class="bg-gray-100 p-4">
+    <div class="bg-gray-100 p-4">
         <div class="max-w-md mx-auto bg-white p-4 rounded shadow">
             <h1 class="text-xl font-bold mb-4">Form Input Barang</h1>
 
@@ -154,6 +146,5 @@
             setTimeout(() => popup.classList.add('hidden'), 3000);
         }
         </script>
-    </body>
-    </html>
+    </div>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- remove standalone HTML skeleton and CDN tailwind script from mobile barang view
- rely on app layout slot with Vite-managed assets for styling and scripts

## Testing
- `./vendor/bin/pest` *(fails: Database file at path ... does not exist)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac75be78d0832591942c76b607984d