### PR TITLE
Add inventory with barcode generation and borrowing workflow

### DIFF
--- a/app/Http/Controllers/BorrowController.php
+++ b/app/Http/Controllers/BorrowController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\BorrowRecord;
+use App\Models\Item;
+use Illuminate\Http\Request;
+
+class BorrowController extends Controller
+{
+    /**
+     * Borrow an item.
+     */
+    public function borrow(Request $request)
+    {
+        $data = $request->validate([
+            'item_id' => 'required|exists:items,id',
+            'user_id' => 'required|exists:users,id',
+            'quantity' => 'required|integer|min:1',
+        ]);
+
+        $item = Item::findOrFail($data['item_id']);
+
+        if ($item->stock < $data['quantity']) {
+            return response()->json(['message' => 'Insufficient stock'], 422);
+        }
+
+        $item->decrement('stock', $data['quantity']);
+
+        $record = BorrowRecord::create([
+            'item_id' => $data['item_id'],
+            'user_id' => $data['user_id'],
+            'quantity' => $data['quantity'],
+            'borrowed_at' => now(),
+        ]);
+
+        return response()->json($record);
+    }
+
+    /**
+     * Return an item.
+     */
+    public function returnItem(BorrowRecord $record)
+    {
+        if ($record->returned_at) {
+            return response()->json(['message' => 'Item already returned'], 422);
+        }
+
+        $record->item->increment('stock', $record->quantity);
+        $record->update(['returned_at' => now()]);
+
+        return response()->json($record);
+    }
+}

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Item;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Milon\Barcode\DNS1D;
+
+class ItemController extends Controller
+{
+    /**
+     * Store a newly created item in storage and generate its barcode.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'condition' => 'nullable|string|max:255',
+            'stock' => 'required|integer|min:0',
+        ]);
+
+        $code = strtoupper(Str::random(10));
+        $path = 'barcodes/' . $code . '.png';
+        $png = (new DNS1D())->getBarcodePNG($code, 'C128');
+        Storage::disk('public')->put($path, base64_decode($png));
+
+        $item = Item::create(array_merge($data, [
+            'barcode' => $code,
+            'barcode_path' => $path,
+        ]));
+
+        return response()->json($item, 201);
+    }
+}

--- a/app/Models/BorrowRecord.php
+++ b/app/Models/BorrowRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BorrowRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'item_id',
+        'user_id',
+        'quantity',
+        'borrowed_at',
+        'returned_at',
+    ];
+
+    protected $casts = [
+        'borrowed_at' => 'datetime',
+        'returned_at' => 'datetime',
+    ];
+
+    public function item(): BelongsTo
+    {
+        return $this->belongsTo(Item::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Item extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'description',
+        'condition',
+        'stock',
+        'barcode',
+        'barcode_path',
+    ];
+
+    /**
+     * Get borrow records for the item.
+     */
+    public function borrowRecords(): HasMany
+    {
+        return $this->hasMany(BorrowRecord::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.31",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9",
+        "milon/barcode": "^12.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1cd2c371cbccef7411ce40d4e53a7c7",
+    "content-hash": "f3bc7e4e0ca9709f01d882fff772b273",
     "packages": [
         {
             "name": "brick/math",
@@ -2005,6 +2005,81 @@
                 }
             ],
             "time": "2024-12-08T08:18:47+00:00"
+        },
+        {
+            "name": "milon/barcode",
+            "version": "v12.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/milon/barcode.git",
+                "reference": "252dc9a530c72454bc6cefb8d274c2acaba24f15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/milon/barcode/zipball/252dc9a530c72454bc6cefb8d274c2acaba24f15",
+                "reference": "252dc9a530c72454bc6cefb8d274c2acaba24f15",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "illuminate/support": "^7.0|^8.0|^9.0|^10.0 | ^11.0 | ^12.0",
+                "php": "^7.3 | ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "DNS1D": "Milon\\Barcode\\Facades\\DNS1DFacade",
+                        "DNS2D": "Milon\\Barcode\\Facades\\DNS2DFacade"
+                    },
+                    "providers": [
+                        "Milon\\Barcode\\BarcodeServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Milon\\Barcode": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Nuruzzaman Milon",
+                    "email": "contact@milon.im"
+                }
+            ],
+            "description": "Barcode generator like Qr Code, PDF417, C39, C39+, C39E, C39E+, C93, S25, S25+, I25, I25+, C128, C128A, C128B, C128C, 2-Digits UPC-Based Extention, 5-Digits UPC-Based Extention, EAN 8, EAN 13, UPC-A, UPC-E, MSI (Variation of Plessey code)",
+            "keywords": [
+                "CODABAR",
+                "CODE 128",
+                "CODE 39",
+                "barcode",
+                "datamatrix",
+                "ean",
+                "laravel",
+                "pdf417",
+                "qr code",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/milon/barcode/issues",
+                "source": "https://github.com/milon/barcode/tree/v12.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/nuruzzamanmilon",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/milon",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-24T18:09:25+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Item;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<Item> */
+class ItemFactory extends Factory
+{
+    protected $model = Item::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+            'condition' => 'baik',
+            'stock' => 10,
+            'barcode' => strtoupper(Str::random(10)),
+            'barcode_path' => 'barcodes/' . Str::random(10) . '.png',
+        ];
+    }
+}

--- a/database/migrations/2025_08_25_160124_create_items_table.php
+++ b/database/migrations/2025_08_25_160124_create_items_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('items', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('condition')->nullable();
+            $table->integer('stock')->default(0);
+            $table->string('barcode')->unique();
+            $table->string('barcode_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('items');
+    }
+};

--- a/database/migrations/2025_08_25_160131_create_borrow_records_table.php
+++ b/database/migrations/2025_08_25_160131_create_borrow_records_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('borrow_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('item_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->integer('quantity');
+            $table->timestamp('borrowed_at');
+            $table->timestamp('returned_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('borrow_records');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ItemController;
+use App\Http\Controllers\BorrowController;
+
+Route::post('/items', [ItemController::class, 'store']);
+Route::post('/borrow', [BorrowController::class, 'borrow']);
+Route::post('/return/{record}', [BorrowController::class, 'returnItem']);
+

--- a/tests/Feature/BorrowReturnTest.php
+++ b/tests/Feature/BorrowReturnTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Item;
+use App\Models\User;
+use App\Models\BorrowRecord;
+use Illuminate\Support\Facades\Storage;
+
+it('creates an item with barcode', function () {
+    Storage::fake('public');
+
+    $response = $this->postJson('/api/items', [
+        'name' => 'Camera',
+        'description' => '4K camera',
+        'condition' => 'baik',
+        'stock' => 5,
+    ]);
+
+    $response->assertCreated();
+    $item = Item::first();
+    expect($item->barcode)->not->toBeNull();
+    expect(Storage::disk('public')->exists($item->barcode_path))->toBeTrue();
+});
+
+it('borrows and returns an item', function () {
+    Storage::fake('public');
+    $item = Item::factory()->create(['stock' => 10]);
+    $user = User::factory()->create();
+
+    $borrow = $this->postJson('/api/borrow', [
+        'item_id' => $item->id,
+        'user_id' => $user->id,
+        'quantity' => 2,
+    ]);
+
+    $borrow->assertOk();
+    $item->refresh();
+    expect($item->stock)->toBe(8);
+
+    $record = BorrowRecord::first();
+    $return = $this->postJson('/api/return/'.$record->id);
+
+    $return->assertOk();
+    $item->refresh();
+    expect($item->stock)->toBe(10);
+    expect($record->fresh()->returned_at)->not->toBeNull();
+});
+


### PR DESCRIPTION
## Summary
- track broadcasting equipment in an `items` table with description, condition, stock and stored barcode image
- record borrow and return transactions that adjust item stock
- expose API routes for adding items, borrowing and returning gear

## Testing
- `php artisan test` *(fails: Vite manifest not found)*
- `php artisan test tests/Feature/BorrowReturnTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac888326788325b8b43713fb14e764